### PR TITLE
procServ unix socket fallback

### DIFF
--- a/iocBoot/iocGalilDmc30017/runProcServ.sh
+++ b/iocBoot/iocGalilDmc30017/runProcServ.sh
@@ -7,8 +7,9 @@ set +u
 . ./parseCMDOpts.sh "$@"
 
 # Use defaults if not set
+UNIX_SOCKET=""
 if [ -z "${DEVICE_TELNET_PORT}" ]; then
-   DEVICE_TELNET_PORT="20000"
+    UNIX_SOCKET="true"
 fi
 
 if [ -z "${DMC30017_INSTANCE}" ]; then
@@ -18,4 +19,8 @@ fi
 set -u
 
 # Run run*.sh scripts with procServ
-/usr/local/bin/procServ -f -n DMC30017_${DMC30017_INSTANCE} -i ^C^D ${DEVICE_TELNET_PORT} ./runGalilDmc30017.sh "$@"
+if [ "${UNIX_SOCKET}" ]; then
+    /usr/local/bin/procServ -f -n DMC30017_${DMC30017_INSTANCE} -i ^C^D unix:./procserv.sock ./runGalilDmc30017.sh "$@"
+else
+    /usr/local/bin/procServ -f -n DMC30017_${DMC30017_INSTANCE} -i ^C^D ${DEVICE_TELNET_PORT} ./runGalilDmc30017.sh "$@"
+fi


### PR DESCRIPTION
Instead of using the default port value, the runProcServ.sh script will use UNIX sockets.